### PR TITLE
Fix #5 by adding a --include-albums argument to argparser.

### DIFF
--- a/fresh.py
+++ b/fresh.py
@@ -68,6 +68,7 @@ def main():
     argparser.add_argument("-s", "--sort", help="sort by hot or new", type=int)
     argparser.add_argument("-l", "--limit", help="how many posts to grab", type=int)
     argparser.add_argument("-t", "--threshold", help="only post with score above threshold", type=int)
+    argparser.add_argument("-ia", "--include-albums", help="include tracks from albums", action="store_true")
     argparser.add_argument("-v", "--verbose", help="output songs being added and other info", action="store_true")
     args = argparser.parse_args()
     
@@ -75,7 +76,8 @@ def main():
     l = args.limit if args.limit else False
     choice = args.sort if args.sort else None
     threshold = args.threshold if args.threshold else None
-            
+    includeAlbums = True if args.include_albums else False
+
     # connect to reddit bot
     reddit = praw.Reddit('bot1')
     subreddit = reddit.subreddit('hiphopheads')
@@ -123,8 +125,8 @@ def main():
         if sub.domain == "open.spotify.com":
 
             # check if post is a track or album
-            isTrack = re.search('track', sub.url)
-            if isTrack != None:
+            isMatch = re.search('(track|album)', sub.url)
+            if isMatch != None:
                 if verbose:
                     print("Post: ", sub.title)
                     print("URL: ", sub.url)
@@ -137,11 +139,16 @@ def main():
 
                 # handle possible query string in url
                 url = sub.url.split('?')
-                if url != None:
-                    tracks.append(url[0])
-                else:
-                    tracks.append(sub.url)
+                formattedUrl = url[0] if url != None else sub.url
 
+                # handle adding tracks from albums
+                if includeAlbums and isMatch.group(1) == 'album':
+                    tracksInAlbum = spotifyObj.album_tracks(formattedUrl)
+                    trackIds = [item['external_urls']['spotify'] for item in tracksInAlbum['items']]
+                    tracks.extend(trackIds)
+                # handle adding tracks
+                elif isMatch.group(1) == 'track':
+                    tracks.append(formattedUrl)
 
     # handle remove duplicates of tracks before adding new tracks
     if tracks != []:


### PR DESCRIPTION
If the URL is found to contain "album" it will poll Spotipy for the tracks in that album. Those tracks will then be added to the tracks list. The order of the matches are maintained.
Used `item['external_urls']['spotify']` to keep a steady format for the tracks list. Could use `item['id']` for brevity and more consistency.