### PR TITLE
Display available playlists

### DIFF
--- a/fresh.py
+++ b/fresh.py
@@ -17,97 +17,67 @@ def str2bool(v):
     else:
         raise argparse.ArgumentTypeError('Boolean value expected.')
 
-# prompt user to add playlists
-def addPlaylists(playlists):
-    playlistsCopy = playlists[:]
-    enteringPlaylists = True
-    while enteringPlaylists:
-        playlistsCopy.append(input('Enter your Playlist ID:' ).strip())
-        enteringPlaylists = str2bool(input('Would you like to enter another playlist ID? [Y/N] ').strip())
-    return playlistsCopy
-
-# prompt user to remove playlists
-def removePlaylists(playlists):
-    playlistsCopy = playlists[:]
-    removingPlaylists = True
-    while removingPlaylists:
-        printPlaylists(playlistsCopy)
-        index = input('Enter the number of the playlist you would like to remove: ').strip()
-        try:
-            index = int(index)
-            del playlistsCopy[index-1]
-        except:
-            print("That playlist number doesn't exist!")
-        removingPlaylists = str2bool(input('Would you like to remove another playlist? ').strip())
-    return playlistsCopy
-
-# print out numbered list of playlists
-def printPlaylists(playlists):
-    print("\nYour current playlists are:")
-    for index, playlist in enumerate(playlists):
-        print(f"{index+1}. {playlist}")
-    print()
-
 def createUser():
+    user = None
     # read config file
-    try:
-        if not os.path.isfile('.config.ini'):
-            # get credentials 
-            s_client_id = input('Enter your Spotify Client ID: ').strip()
-            s_client_secret = input('Enter your Spotify Client Secret: ').strip()
-            username = input('Enter your Username: ').strip()
-            playlists = addPlaylists([])
-            redirect = input('Enter your Redirect URI: ').strip()
-            r_client_id = input('Enter your Reddit Client ID: ').strip()
-            r_client_secret = input('Enter your  Reddit Client Secret: ').strip()
+    # try:
+    if not os.path.isfile('.config.ini'):
+        # get credentials 
+        s_client_id = input('Enter your Spotify Client ID: ').strip()
+        s_client_secret = input('Enter your Spotify Client Secret: ').strip()
+        username = input('Enter your Username: ').strip()
+        redirect = input('Enter your Redirect URI: ').strip()
+        r_client_id = input('Enter your Reddit Client ID: ').strip()
+        r_client_secret = input('Enter your Reddit Client Secret: ').strip()
+        user = User(username, s_client_id, s_client_secret, redirect, [])
+        user.addPlaylists()
 
-            # write spotify config
-            s_config = ConfigParser()
-            s_config['spotify'] = {
-                'client_id': s_client_id,
-                'client_secret': s_client_secret,
-                'username': username,
-                'playlist_id': ','.join(playlists),
-                'redirect_uri': redirect
-            }
+        # write spotify config
+        s_config = ConfigParser()
+        s_config['spotify'] = {
+            'client_id': s_client_id,
+            'client_secret': s_client_secret,
+            'username': username,
+            'playlist_id': user.getPlaylistsAsString(),
+            'redirect_uri': redirect
+        }
 
-            # write praw config
-            r_config = ConfigParser()
-            r_config['bot1'] = {
-                'client_id': r_client_id,
-                'client_secret': r_client_secret,
-                'user_agent': 'FreshScript'
+        # write praw config
+        r_config = ConfigParser()
+        r_config['bot1'] = {
+            'client_id': r_client_id,
+            'client_secret': r_client_secret,
+            'user_agent': 'FreshScript'
 
-            }
-            with open('.config.ini', 'w') as f:
-                s_config.write(f)
+        }
+        with open('.config.ini', 'w') as f:
+            s_config.write(f)
 
-            with open('praw.ini', 'w') as p:
-                r_config.write(p)
+        with open('praw.ini', 'w') as p:
+            r_config.write(p)
 
+    else:
+        # parse config
+        parser = ConfigParser()
+        parser.read('.config.ini')
 
-        else:
-            # parse config
-            parser = ConfigParser()
-            parser.read('.config.ini')
-
-            # spotify info
-            username = parser.get('spotify', 'username')
-            playlists = parser.get('spotify', 'playlist_id') #returns a comma separated list of playlists
-            s_client_id = parser.get('spotify', 'client_id')
-            s_client_secret = parser.get('spotify', 'client_secret')
-            redirect = parser.get('spotify', 'redirect_uri')
-
+        # spotify info
+        username = parser.get('spotify', 'username')
+        playlists = parser.get('spotify', 'playlist_id').split(',')
+        s_client_id = parser.get('spotify', 'client_id')
+        s_client_secret = parser.get('spotify', 'client_secret')
+        redirect = parser.get('spotify', 'redirect_uri')
+        user = User(username, s_client_id, s_client_secret, redirect, playlists)
 
         '''
         TODO
         config['youtube'] = {}
         config['soundcloud'] = {}
         '''
-    except:
-        print('config failure')
+    # except Exception as e:
+    #     print(f'config failure: {e}')
 
-    return User(username, s_client_id, s_client_secret, redirect, playlists)
+    return user
 
 
   
@@ -214,33 +184,30 @@ def extract_track_url(search):
                         url = external_urls['spotify']
                         return url
 
-def manage_playlists(playlistStr):
+def manage_playlists(user):
     """
     List, add, and remove playlists.
     Parameters
     ----------
-    playlistStr : string
-        String of user playlists.
+    user : user object
+        Object containing all user data.
     """
-    playlists = playlistStr.split(',')
-    printPlaylists(playlists)
+    user.printPlaylists()
 
     if str2bool(input('Would you like to remove a playlist? ').strip()):
-        playlists = removePlaylists(playlists)
+        user.removePlaylists()
     
     if str2bool(input('Would you like to add a playlist? ').strip()):
-        playlists = addPlaylists(playlists)
+        user.addPlaylists()
     
-    printPlaylists(playlists)
-    playlistStr = ','.join(playlists)
+    user.printPlaylists()
+    playlistStr = user.getPlaylistsAsString()
     
     config = ConfigParser()
     config.read('.config.ini')
     config['spotify']['playlist_id'] = playlistStr
     with open('.config.ini', 'w') as f:
-        config.write(f)
-
-    return playlistStr      
+        config.write(f)      
 
 def main():
     user = createUser()
@@ -277,7 +244,7 @@ def main():
         print('Welcome to the HipHopHeads Fresh Script')
     
     if managePlaylists:
-        user.playlist = manage_playlists(user.playlist)
+        manage_playlists(user)
 
     if not choice:
         inputPrompt = textwrap.dedent("""\
@@ -377,7 +344,7 @@ def main():
         try:
             if len(tracks_array) > 1:
                 for tr in tracks_array:
-                    for playlist in user.playlist.split(','):
+                    for playlist in user.playlists:
                         # retrive information of the tracks in user's playlist
                         existing_tracks = spotifyObj.user_playlist_tracks(user.username, playlist)
                         spotifyObj.user_playlist_remove_all_occurrences_of_tracks(user.username, playlist, tr)

--- a/fresh.py
+++ b/fresh.py
@@ -20,62 +20,62 @@ def str2bool(v):
 def createUser():
     user = None
     # read config file
-    # try:
-    if not os.path.isfile('.config.ini'):
-        # get credentials 
-        s_client_id = input('Enter your Spotify Client ID: ').strip()
-        s_client_secret = input('Enter your Spotify Client Secret: ').strip()
-        username = input('Enter your Username: ').strip()
-        redirect = input('Enter your Redirect URI: ').strip()
-        r_client_id = input('Enter your Reddit Client ID: ').strip()
-        r_client_secret = input('Enter your Reddit Client Secret: ').strip()
-        user = User(username, s_client_id, s_client_secret, redirect, [])
-        user.addPlaylists()
+    try:
+        if not os.path.isfile('.config.ini'):
+            # get credentials 
+            s_client_id = input('Enter your Spotify Client ID: ').strip()
+            s_client_secret = input('Enter your Spotify Client Secret: ').strip()
+            username = input('Enter your Username: ').strip()
+            redirect = input('Enter your Redirect URI: ').strip()
+            r_client_id = input('Enter your Reddit Client ID: ').strip()
+            r_client_secret = input('Enter your Reddit Client Secret: ').strip()
+            user = User(username, s_client_id, s_client_secret, redirect, [])
+            user.addPlaylists()
 
-        # write spotify config
-        s_config = ConfigParser()
-        s_config['spotify'] = {
-            'client_id': s_client_id,
-            'client_secret': s_client_secret,
-            'username': username,
-            'playlist_id': user.getPlaylistsAsString(),
-            'redirect_uri': redirect
-        }
+            # write spotify config
+            s_config = ConfigParser()
+            s_config['spotify'] = {
+                'client_id': s_client_id,
+                'client_secret': s_client_secret,
+                'username': username,
+                'playlist_id': user.getPlaylistsAsString(),
+                'redirect_uri': redirect
+            }
 
-        # write praw config
-        r_config = ConfigParser()
-        r_config['bot1'] = {
-            'client_id': r_client_id,
-            'client_secret': r_client_secret,
-            'user_agent': 'FreshScript'
+            # write praw config
+            r_config = ConfigParser()
+            r_config['bot1'] = {
+                'client_id': r_client_id,
+                'client_secret': r_client_secret,
+                'user_agent': 'FreshScript'
 
-        }
-        with open('.config.ini', 'w') as f:
-            s_config.write(f)
+            }
+            with open('.config.ini', 'w') as f:
+                s_config.write(f)
 
-        with open('praw.ini', 'w') as p:
-            r_config.write(p)
+            with open('praw.ini', 'w') as p:
+                r_config.write(p)
 
-    else:
-        # parse config
-        parser = ConfigParser()
-        parser.read('.config.ini')
+        else:
+            # parse config
+            parser = ConfigParser()
+            parser.read('.config.ini')
 
-        # spotify info
-        username = parser.get('spotify', 'username')
-        playlists = parser.get('spotify', 'playlist_id').split(',')
-        s_client_id = parser.get('spotify', 'client_id')
-        s_client_secret = parser.get('spotify', 'client_secret')
-        redirect = parser.get('spotify', 'redirect_uri')
-        user = User(username, s_client_id, s_client_secret, redirect, playlists)
+            # spotify info
+            username = parser.get('spotify', 'username')
+            playlists = parser.get('spotify', 'playlist_id').split(',')
+            s_client_id = parser.get('spotify', 'client_id')
+            s_client_secret = parser.get('spotify', 'client_secret')
+            redirect = parser.get('spotify', 'redirect_uri')
+            user = User(username, s_client_id, s_client_secret, redirect, playlists)
 
-        '''
-        TODO
-        config['youtube'] = {}
-        config['soundcloud'] = {}
-        '''
-    # except Exception as e:
-    #     print(f'config failure: {e}')
+            '''
+            TODO
+            config['youtube'] = {}
+            config['soundcloud'] = {}
+            '''
+    except Exception as e:
+        print(f'config failure: {e}')
 
     return user
 
@@ -194,10 +194,10 @@ def manage_playlists(user):
     """
     user.printPlaylists()
 
-    if str2bool(input('Would you like to remove a playlist? ').strip()):
+    if str2bool(input('Would you like to remove a playlist? [Y/N] ').strip()):
         user.removePlaylists()
     
-    if str2bool(input('Would you like to add a playlist? ').strip()):
+    if str2bool(input('Would you like to add a playlist? [Y/N] ').strip()):
         user.addPlaylists()
     
     user.printPlaylists()

--- a/models.py
+++ b/models.py
@@ -1,15 +1,14 @@
+import spotipy
 import spotipy.util as util
 
 # user object to hold the things
-
-
 class User:
-    def __init__(self, username, client_id, client_secret, redirect, playlist):
+    def __init__(self, username, client_id, client_secret, redirect, playlists):
         self.username = username
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect = redirect
-        self.playlist = playlist
+        self.playlists = playlists
         self.token = self.getToken()
 
     def getToken(self):
@@ -21,3 +20,51 @@ class User:
             token = util.prompt_for_user_token(self.username, 'playlist-modify-public', self.client_id, self.client_secret, self.redirect)
 
         return token
+
+    def getPlaylistsAsString(self):
+        return ','.join(self.playlists)
+
+    # this is just a copy of the function from the other file. 
+    # it probably should be pulled out into a utility class
+    def str2bool(self, v):
+        if v.lower() in ('yes', 'true', 't', 'y', '1'):
+            return True
+        elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+            return False
+        else:
+            raise argparse.ArgumentTypeError('Boolean value expected.')
+
+    # prompt user to add playlists
+    def addPlaylists(self):
+        sp = spotipy.Spotify(auth=self.token)
+        spotifyPlaylists = sp.current_user_playlists()
+        for playlist in spotifyPlaylists['items']:
+            #if playlist['owner']['id'] == self.username:
+            print()
+            print(playlist['owner']['id'])
+            print(playlist['name'])
+            print('  total tracks', playlist['tracks']['total'])
+        enteringPlaylists = True
+        while enteringPlaylists:
+            self.playlists.append(input('Enter your Playlist ID: ' ).strip())
+            enteringPlaylists = self.str2bool(input('Would you like to enter another playlist ID? [Y/N] ').strip())
+
+    # prompt user to remove playlists
+    def removePlaylists(self):
+        removingPlaylists = True
+        while removingPlaylists:
+            self.printPlaylists(playlistsCopy)
+            index = input('Enter the number of the playlist you would like to remove: ').strip()
+            try:
+                index = int(index)
+                del self.playlists[index-1]
+            except:
+                print("That playlist number doesn't exist!")
+            removingPlaylists = self.str2bool(input('Would you like to remove another playlist? ').strip())
+
+    # print out numbered list of playlists
+    def printPlaylists(self):
+        print("\nYour current playlists are:")
+        for index, playlist in enumerate(self.playlists):
+            print(f"{index+1}. {playlist}")
+        print()

--- a/models.py
+++ b/models.py
@@ -38,16 +38,29 @@ class User:
     def addPlaylists(self):
         sp = spotipy.Spotify(auth=self.token)
         spotifyPlaylists = sp.current_user_playlists()
-        for playlist in spotifyPlaylists['items']:
-            #if playlist['owner']['id'] == self.username:
+        userId = sp.current_user()['id']
+        ownedPlaylists = list(filter(lambda x: x['owner']['id'] == userId, spotifyPlaylists['items']))
+        for i, playlist in enumerate(ownedPlaylists):
             print()
-            print(playlist['owner']['id'])
-            print(playlist['name'])
+            print(f"{i+1}. {playlist['name']}")
             print('  total tracks', playlist['tracks']['total'])
+        print()
         enteringPlaylists = True
+        playlistsToAdd = []
+        playlistsToAddIndices = []
         while enteringPlaylists:
-            self.playlists.append(input('Enter your Playlist ID: ' ).strip())
+            index = input('Enter the number of the playlist you would like to add: ').strip()
+            try:
+                index = int(index)
+                if index < 1 or index > len(ownedPlaylists):
+                    raise Exception('Input index out of bounds!')
+                if index not in playlistsToAddIndices:
+                    playlistsToAdd.append(ownedPlaylists[index-1]['id'])
+                    playlistsToAddIndices.append(index)
+            except:
+                print("That playlist number doesn't exist!")
             enteringPlaylists = self.str2bool(input('Would you like to enter another playlist ID? [Y/N] ').strip())
+        self.playlists.extend(playlistsToAdd)
 
     # prompt user to remove playlists
     def removePlaylists(self):
@@ -60,7 +73,7 @@ class User:
                 del self.playlists[index-1]
             except:
                 print("That playlist number doesn't exist!")
-            removingPlaylists = self.str2bool(input('Would you like to remove another playlist? ').strip())
+            removingPlaylists = self.str2bool(input('Would you like to remove another playlist? [Y/N] ').strip())
 
     # print out numbered list of playlists
     def printPlaylists(self):


### PR DESCRIPTION
#### Summary

- address issue #30 
- pulls spotify playlists owned by the current user to display before adding playlists
- instead of adding playlists by id, the user now selects the corresponding playlist number from the printed out list
- I also did a decent amount of refactoring as I was finding that it made more sense for the playlist helper functions (add, remove, print) to live within the `User` class, since several user properties are needed for the playlist lookup call anyway. This also means we can just edit the playlists of the user instead of having to pass/return a list through a bunch of functions.

#### Other Notes/Issue Suggestions

- I had to copy the `str2bool` function into the `User` class to avoid having a circular dependency when importing it from the main file, but I think in the future this along with some of the other utility functions in the main file could be moved to a utility class. This would also help to shorted the large main file. Perhaps this would be a good beginner friendly issue? 😃 
- The `printPlaylists` still prints out the playlists' ids, and I thought changing that was a little outside the scope of this issue, but I would be happy to work on that in a separate pull request. If we want to have this done, should we do a lookup by id every time the playlists need to be printed out or should we store the corresponding names of the playlists in the config file? I tend to lean towards the latter to reduce the amount of api calls we need to perform.