### PR TITLE
Load credentials file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ praw.ini
 __pycache__
 *.ini`
 venv/*
+credentials.json

--- a/README.md
+++ b/README.md
@@ -9,13 +9,34 @@ This program will search for spotify tracks posted in the HipHopHeads subreddit 
 
 ### Prerequisites
 
-This project uses Python3. You will need to setup a Spotify developer account and register your app. You will need the following things for this code:
+This project uses Python3. You will need to setup a Spotify developer account and register your app and obtain the following information:
 * client id
 * client secret
 * your spotify username
 * playlist id of the playlist you want to add the tracks to
 * the url you want to redirect to for authentication, i.e. http://google.com/
- You will also need to setup a reddit instance with praw. [Heres](https://pythonforengineers.com/build-a-reddit-bot-part-1/) a useful guide I used to do this.
+  * this must be added under your app settings > `Redirect URIs` 
+
+You will also need to setup a reddit instance with praw. [Heres](https://pythonforengineers.com/build-a-reddit-bot-part-1/) a useful guide I used to do this.
+
+### Setup
+
+To set up your credentials, create a new file called `credentials.json` in the root of the project with the following contents:
+
+```
+{
+    "spotify": {
+        "username": "[Spotify username]",
+        "client_id": "[Spotify client id]",
+        "client_secret": "[Spotify client secret]",
+        "redirect": "[redirect uri]"
+    },
+    "reddit": {
+        "client_id": "[praw client id]",
+        "client_secret": "[praw client secret]"
+    }
+}
+```
  
 ### Installing dependencies
 This project uses a dependency manager called [pipenv](https://pipenv.readthedocs.io). Follow the instructions to install it [here](https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv).

--- a/README.md
+++ b/README.md
@@ -9,17 +9,19 @@ This program will search for spotify tracks posted in the HipHopHeads subreddit 
 
 ### Prerequisites
 
-This project uses Python3. You will need to setup a Spotify developer account and register your app and obtain the following information:
+This project uses Python3.
+
+You will need to setup a Spotify developer account and register your app and obtain the following information:
 * client id
 * client secret
 * your spotify username
 * playlist id of the playlist you want to add the tracks to
 * the url you want to redirect to for authentication, i.e. http://google.com/
-  * this must be added under your app settings > `Redirect URIs` 
+  * this must be added under your app settings > Redirect URIs 
 
-You will also need to setup a reddit instance with praw. [Heres](https://pythonforengineers.com/build-a-reddit-bot-part-1/) a useful guide I used to do this.
+You will also need to setup a reddit instance with praw. [Here's](https://pythonforengineers.com/build-a-reddit-bot-part-1/) a useful guide I used to do this.
 
-### Setup
+### Setup your Credentials
 
 To set up your credentials, create a new file called `credentials.json` in the root of the project with the following contents:
 

--- a/fresh.py
+++ b/fresh.py
@@ -38,22 +38,24 @@ def createUserConfig(user, config_path='.config.ini'):
     with open(config_path, 'w') as f:
         s_config.write(f)
 
-def createPrawConfig(r_client_id, r_client_secret,
+def createPrawConfig(client_id, client_secret,
                      praw_path='praw.ini'):
     """
     Create praw.ini file for Reddit credentials.
 
     Parameters
     ----------
-    user: User object
-        Spotify user object.
+    client_id: str
+        Reddit app client id.
+    client_secret: str
+        Reddit app client secret.
     praw_path: str
         Path to praw.ini.
     """
     r_config = ConfigParser()
     r_config['bot1'] = {
-        'client_id': r_client_id,
-        'client_secret': r_client_secret,
+        'client_id': client_id,
+        'client_secret': client_secret,
         'user_agent': 'FreshScript'
     }
 
@@ -64,7 +66,7 @@ def createUser():
     user = None
     # read config file
     try:
-        if os.path.exists('credentials.json') and not os.path.isfile('.config.ini'):
+        if not os.path.isfile('.config.ini'):
             # load credentials file
             with open('credentials.json', 'r') as f:
                 credentials = json.load(f)
@@ -83,10 +85,12 @@ def createUser():
 
             # write config files
             createUserConfig(user)
+
             createPrawConfig(p_credentials['client_id'],
                              p_credentials['client_secret'])
 
-        elif not os.path.isfile('.config.ini'):
+        elif not os.path.isfile('.config.ini') \
+             and not os.path.isfile('credentials.json'):
             print('Credentials file not found!')
 
             # get credentials

--- a/fresh.py
+++ b/fresh.py
@@ -15,7 +15,7 @@ import cutie
 
 def createUserConfig(user, config_path='.config.ini'):
     """
-    Create Spotify .config.ini file for Spotify credentials.
+    Create .config.ini file for Spotify credentials.
 
     Parameters
     ----------
@@ -66,7 +66,7 @@ def createUser():
     user = None
     # read config file
     try:
-        if not os.path.isfile('.config.ini'):
+        if os.path.exists('credentials.json') and not os.path.isfile('.config.ini'):
             # load credentials file
             with open('credentials.json', 'r') as f:
                 credentials = json.load(f)
@@ -89,8 +89,7 @@ def createUser():
             createPrawConfig(p_credentials['client_id'],
                              p_credentials['client_secret'])
 
-        elif not os.path.isfile('.config.ini') \
-             and not os.path.isfile('credentials.json'):
+        elif not os.path.isfile('.config.ini'):
             print('Credentials file not found!')
 
             # get credentials


### PR DESCRIPTION
I refactored the `createUser()` method to take in a `credentials.json` file so that when starting from scratch, the user/developer/tester doesn't have to go through the walkthrough of copy/pasting their credentials one by one when running `python3 fresh.py`.

I also added two new methods `createUserConfig()` and `createPrawConfig` to make the code more readable.

The README.md and .gitignore are also updated accordingly.