### PR TITLE
Fixed Exception Caused by Spaces in Sub Reddit name

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ def home(Name=None):
 
 @app.route('/tracks', methods=['GET', 'POST'])
 def tracks(Name=None):
-    sub_reddit = request.form.get('inputvalue').strip()
+    sub_reddit = request.form.get('inputvalue').replace(" ","")
     tag_choice = request.form.get('taglist')
     reddit_data = ""
     if sub_reddit:


### PR DESCRIPTION
![Screenshot (80)](https://user-images.githubusercontent.com/47831211/88473457-4a9c5180-cf3b-11ea-87ab-ce6f431d53e9.png)

The split() wasn't working as expected.
Replaced the function with string replace. The Prawcore Exception doesn't occur now when searching for subreddit with spaces. 